### PR TITLE
feat: arduino uno wifi r4 http

### DIFF
--- a/src/deploii_certs.h
+++ b/src/deploii_certs.h
@@ -8,37 +8,37 @@
 /*
  * Public key for encrypted communications with Deploii server
  */
-static const char *buypass_cert =
-    "-----BEGIN CERTIFICATE-----\n"
-    "MIIFWTCCA0GgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBOMQswCQYDVQQGEwJOTzEd\n"
-    "MBsGA1UECgwUQnV5cGFzcyBBUy05ODMxNjMzMjcxIDAeBgNVBAMMF0J1eXBhc3Mg\n"
-    "Q2xhc3MgMiBSb290IENBMB4XDTEwMTAyNjA4MzgwM1oXDTQwMTAyNjA4MzgwM1ow\n"
-    "TjELMAkGA1UEBhMCTk8xHTAbBgNVBAoMFEJ1eXBhc3MgQVMtOTgzMTYzMzI3MSAw\n"
-    "HgYDVQQDDBdCdXlwYXNzIENsYXNzIDIgUm9vdCBDQTCCAiIwDQYJKoZIhvcNAQEB\n"
-    "BQADggIPADCCAgoCggIBANfHXvfBB9R3+0Mh9PT1aeTuMgHbo4Yf5FkNuud1g1Lr\n"
-    "6hxhFUi7HQfKjK6w3Jad6sNgkoaCKHOcVgb/S2TwDCo3SbXlzwx87vFKu3MwZfPV\n"
-    "L4O2fuPn9Z6rYPnT8Z2SdIrkHJasW4DptfQxh6NR/Md+oW+OU3fUl8FVM5I+GC91\n"
-    "1K2GScuVr1QGbNgGE41b/+EmGVnAJLqBcXmQRFBoJJRfuLMR8SlBYaNByyM21cHx\n"
-    "MlAQTn/0hpPshNOOvEu/XAFOBz3cFIqUCqTqc/sLUegTBxj6DvEr0VQVfTzh97QZ\n"
-    "QmdiXnfgolXsttlpF9U6r0TtSsWe5HonfOV116rLJeffawrbD02TTqigzXsu8lkB\n"
-    "arcNuAeBfos4GzjmCleZPe4h6KP1DBbdi+w0jpwqHAAVF41og9JwnxgIzRFo1clr\n"
-    "Us3ERo/ctfPYV3Me6ZQ5BL/T3jjetFPsaRyifsSP5BtwrfKi+fv3FmRmaZ9JUaLi\n"
-    "FRhnBkp/1Wy1TbMz4GHrXb7pmA8y1x1LPC5aAVKRCfLf6o3YBkBjqhHk/sM3nhRS\n"
-    "P/TizPJhk9H9Z2vXUq6/aKtAQ6BXNVN48FP4YUIHZMbXb5tMOA1jrGKvNouicwoN\n"
-    "9SG9dKpN6nIDSdvHXx1iY8f93ZHsM+71bbRuMGjeyNYmsHVee7QHIJihdjK4TWxP\n"
-    "AgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMmAd+BikoL1Rpzz\n"
-    "uvdMw964o605MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAgEAU18h\n"
-    "9bqwOlI5LJKwbADJ784g7wbylp7ppHR/ehb8t/W2+xUbP6umwHJdELFx7rxP462s\n"
-    "A20ucS6vxOOto70MEae0/0qyexAQH6dXQbLArvQsWdZHEIjzIVEpMMpghq9Gqx3t\n"
-    "OluwlN5E40EIosHsHdb9T7bWR9AUC8rmyrV7d35BH16Dx7aMOZawP5aBQW9gkOLo\n"
-    "+fsicdl9sz1Gv7SEr5AcD48Saq/v7h56rgJKihcrdv6sVIkkLE8/trKnToyokZf7\n"
-    "KcZ7XC25y2a2t6hbElGFtQl+Ynhw/qlqYLYdDnkM/crqJIByw5c/8nerQyIKx+u2\n"
-    "DISCLIBrQYoIwOula9+ZEsuK1V6ADJHgJgg2SMX6OBE1/yWDLfJ6v9r9jv6ly0Us\n"
-    "H8SIU653DtmadsWOLB2jutXsMq7Aqqz30XpN69QH4kj3Io6wpJ9qzo6ysmD0oyLQ\n"
-    "I+uUWnpp3Q+/QFesa1lQ2aOZ4W7+jQF5JyMV3pKdewlNWudLSDBaGOYKbeaP4NK7\n"
-    "5t98biGCwWg5TbSYWGZizEqQXsP6JwSxeRV0mcy+rSDeJmAc61ZRpqPq5KM/p/9h\n"
-    "3PFaTWwyI0PurKju7koSCTxdccK+efrCh2gdC/1cacwG0Jp9VJkqyTkaGa9LKkPz\n"
-    "Y11aWOIv4x3kqdbQCtCev9eBCfHJxyYNrJgWVqA=\n"
+const char* buypass_cert = 
+    "-----BEGIN CERTIFICATE-----\n" \
+    "MIIFWTCCA0GgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBOMQswCQYDVQQGEwJOTzEd\n" \
+    "MBsGA1UECgwUQnV5cGFzcyBBUy05ODMxNjMzMjcxIDAeBgNVBAMMF0J1eXBhc3Mg\n" \
+    "Q2xhc3MgMiBSb290IENBMB4XDTEwMTAyNjA4MzgwM1oXDTQwMTAyNjA4MzgwM1ow\n" \
+    "TjELMAkGA1UEBhMCTk8xHTAbBgNVBAoMFEJ1eXBhc3MgQVMtOTgzMTYzMzI3MSAw\n" \
+    "HgYDVQQDDBdCdXlwYXNzIENsYXNzIDIgUm9vdCBDQTCCAiIwDQYJKoZIhvcNAQEB\n" \
+    "BQADggIPADCCAgoCggIBANfHXvfBB9R3+0Mh9PT1aeTuMgHbo4Yf5FkNuud1g1Lr\n" \
+    "6hxhFUi7HQfKjK6w3Jad6sNgkoaCKHOcVgb/S2TwDCo3SbXlzwx87vFKu3MwZfPV\n" \
+    "L4O2fuPn9Z6rYPnT8Z2SdIrkHJasW4DptfQxh6NR/Md+oW+OU3fUl8FVM5I+GC91\n" \
+    "1K2GScuVr1QGbNgGE41b/+EmGVnAJLqBcXmQRFBoJJRfuLMR8SlBYaNByyM21cHx\n" \
+    "MlAQTn/0hpPshNOOvEu/XAFOBz3cFIqUCqTqc/sLUegTBxj6DvEr0VQVfTzh97QZ\n" \
+    "QmdiXnfgolXsttlpF9U6r0TtSsWe5HonfOV116rLJeffawrbD02TTqigzXsu8lkB\n" \
+    "arcNuAeBfos4GzjmCleZPe4h6KP1DBbdi+w0jpwqHAAVF41og9JwnxgIzRFo1clr\n" \
+    "Us3ERo/ctfPYV3Me6ZQ5BL/T3jjetFPsaRyifsSP5BtwrfKi+fv3FmRmaZ9JUaLi\n" \
+    "FRhnBkp/1Wy1TbMz4GHrXb7pmA8y1x1LPC5aAVKRCfLf6o3YBkBjqhHk/sM3nhRS\n" \
+    "P/TizPJhk9H9Z2vXUq6/aKtAQ6BXNVN48FP4YUIHZMbXb5tMOA1jrGKvNouicwoN\n" \
+    "9SG9dKpN6nIDSdvHXx1iY8f93ZHsM+71bbRuMGjeyNYmsHVee7QHIJihdjK4TWxP\n" \
+    "AgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMmAd+BikoL1Rpzz\n" \
+    "uvdMw964o605MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQsFAAOCAgEAU18h\n" \
+    "9bqwOlI5LJKwbADJ784g7wbylp7ppHR/ehb8t/W2+xUbP6umwHJdELFx7rxP462s\n" \
+    "A20ucS6vxOOto70MEae0/0qyexAQH6dXQbLArvQsWdZHEIjzIVEpMMpghq9Gqx3t\n" \
+    "OluwlN5E40EIosHsHdb9T7bWR9AUC8rmyrV7d35BH16Dx7aMOZawP5aBQW9gkOLo\n" \
+    "+fsicdl9sz1Gv7SEr5AcD48Saq/v7h56rgJKihcrdv6sVIkkLE8/trKnToyokZf7\n" \
+    "KcZ7XC25y2a2t6hbElGFtQl+Ynhw/qlqYLYdDnkM/crqJIByw5c/8nerQyIKx+u2\n" \
+    "DISCLIBrQYoIwOula9+ZEsuK1V6ADJHgJgg2SMX6OBE1/yWDLfJ6v9r9jv6ly0Us\n" \
+    "H8SIU653DtmadsWOLB2jutXsMq7Aqqz30XpN69QH4kj3Io6wpJ9qzo6ysmD0oyLQ\n" \
+    "I+uUWnpp3Q+/QFesa1lQ2aOZ4W7+jQF5JyMV3pKdewlNWudLSDBaGOYKbeaP4NK7\n" \
+    "5t98biGCwWg5TbSYWGZizEqQXsP6JwSxeRV0mcy+rSDeJmAc61ZRpqPq5KM/p/9h\n" \
+    "3PFaTWwyI0PurKju7koSCTxdccK+efrCh2gdC/1cacwG0Jp9VJkqyTkaGa9LKkPz\n" \
+    "Y11aWOIv4x3kqdbQCtCev9eBCfHJxyYNrJgWVqA=\n" \
     "-----END CERTIFICATE-----\n";
 
 /*************************************************************************************/

--- a/src/deploii_config.h
+++ b/src/deploii_config.h
@@ -68,7 +68,11 @@ static_assert(DEPLOII_DEBUG >= DEPLOII_DEBUG_NONE && DEPLOII_DEBUG <= DEPLOII_DE
 #endif // !DEPLOII_HTTP_URL
 
 #ifndef DEPLOII_SSL
+#if (defined(ARDUINO_UNOR4_WIFI) && (DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS))
+#define DEPLOII_SSL false
+#else
 #define DEPLOII_SSL true
+#endif
 #endif // !DEPLOII_SSL
 
 /*************************************************************************************/

--- a/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
+++ b/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
@@ -16,8 +16,11 @@
 #if DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS
 #include <WebSocketsClient.h> 
 void _wsEvent(WStype_t type, uint8_t* payload, size_t length);
-void (*_dataCallback)(uint8_t* data, size_t size){nullptr};
+
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
+#if DEPLOII_SSL
+#include "WiFiSSLClient.h"
+#endif // DEPLOII_SSL
 
 #endif // DEPLOII_PROTOCOL
 
@@ -36,7 +39,7 @@ public:
 #if DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS
       : _ws()
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
-
+    : _client()
 #endif // DEPLOII_PROTOCOL
   {
   };
@@ -48,6 +51,12 @@ public:
 #if DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS
     _ws.~WebSocketsClient();
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
+
+#if DEPLOII_SSL
+    _client.~WiFiSSLClient();
+#else
+    _client.~WiFiClient();
+#endif // DEPLOII_SSL
 
 #endif // DEPLOII_PROTOCOL
   };
@@ -69,12 +78,33 @@ public:
   {
 #if DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS
     _ws.sendBIN(data, size);
-    DEPLOII_DPRINT(DEPLOII_DEBUG_VERBOSE, "Sending WEBSOCKET data of size 0x%zx", size);
+    DEPLOII_DPRINT(DEPLOII_DEBUG_VERBOSE, "Sending WEBSOCKET data of size 0x%x", size);
 
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
 
-    //DEPLOII_DPRINT(DEPLOII_DEBUG_VERBOSE, "Sending HTTP data of size 0x%zx", size);
-
+#if DEPLOII_SSL
+    if(_client.connect(DEPLOII_HOST, DEPLOII_PORT))
+#else 
+    if(_client.connect(DEPLOII_HOST, DEPLOII_PORT_NO_SSL))
+#endif // DEPLOII_SSL
+    {
+      DEPLOII_DPRINT(DEPLOII_DEBUG_VERBOSE, "Sending HTTP data of size 0x%x", size);
+      _client.println("POST " DEPLOII_HTTP_URL " HTTP/1.1");
+      _client.println("Host: " DEPLOII_HOST);
+      _client.print("Authorization: ");
+      _client.println(_boardID);
+      _client.println("Content-Type: application/octet-stream");
+      _client.print("Content-Length: ");
+      _client.println((int)size);
+      _client.println();
+      _client.write(data, size);
+    }else{
+      DEPLOII_DPRINT(DEPLOII_DEBUG_INFO, "Failed to connect to HTTP server");
+    }
+    while(_client.available()){
+      Serial.print((char)_client.read());
+    }
+    _client.stop();
 #endif // DEPLOII_PROTOCOL
   };
    void setDataCallback(void (*cb)(uint8_t* data, size_t size)) {
@@ -107,15 +137,19 @@ public:
     _ws.onEvent(_wsEvent);
 
     DEPLOII_DPRINT(DEPLOII_DEBUG_VERBOSE, "Attempting to connect to Websocket server");
-#if DEPLOII_SSL == true
-#pragma message("SSL is currently not supported for this device, please set the DEPLOII_SSL macro to false.")
-    DEPLOII_DPRINT(DEPLOII_DEBUG_INFO, "SSL is currently not supported for this device, please set the DEPLOII_SSL macro to false.");
+#if DEPLOII_SSL
+#pragma message("Websockets with SSL is currently not supported for this device, please set the DEPLOII_SSL macro to false.")
+    DEPLOII_DPRINT(DEPLOII_DEBUG_INFO, "Websockets with SSL is currently not supported for this device, please set the DEPLOII_SSL macro to false.");
     while(true);
 #else
     _ws.begin(DEPLOII_HOST, DEPLOII_PORT_NO_SSL, DEPLOII_WS_URL);
 #endif // DEPLOII_SSL
 
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
+    _boardID = boardID;
+#if DEPLOII_SSL
+    _client.setCACert(buypass_cert);
+#endif
 
 #endif // DEPLOII_PROTOCOL
 
@@ -128,6 +162,12 @@ public:
 
 
 #elif DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_HTTP
+    char* _boardID;
+#if DEPLOII_SSL
+    WiFiSSLClient _client;
+#else
+    WiFiClient _client;
+#endif // DEPLOII_SSL
 
 #endif  // DEPLOII_PROTOCOL
 

--- a/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
+++ b/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
@@ -101,9 +101,6 @@ public:
     }else{
       DEPLOII_DPRINT(DEPLOII_DEBUG_INFO, "Failed to connect to HTTP server");
     }
-    while(_client.available()){
-      Serial.print((char)_client.read());
-    }
     _client.stop();
 #endif // DEPLOII_PROTOCOL
   };

--- a/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
+++ b/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
@@ -21,6 +21,9 @@ void (*_dataCallback)(uint8_t* data, size_t size){nullptr};
 
 #endif // DEPLOII_PROTOCOL
 
+void _defaultCallback(uint8_t*data, size_t size){};
+void (*_dataCallback)(uint8_t* data, size_t size)= &_defaultCallback;
+
 /*************************************************************************************/
 
 class DeploiiHandler

--- a/src/handler/esp32/deploii_handler_esp32.h
+++ b/src/handler/esp32/deploii_handler_esp32.h
@@ -13,7 +13,8 @@
 #include <WiFi.h>
 #endif // DEPLOII_MEDIUM
 
-void (*_dataCallback)(uint8_t* data, size_t size){nullptr};
+void _defaultCallback(uint8_t*data, size_t size){};
+void (*_dataCallback)(uint8_t* data, size_t size) = &_defaultCallback;
 
 #if DEPLOII_PROTOCOL == DEPLOII_PROTOCOL_WEBSOCKETS
 #include <WebSocketsClient.h>


### PR DESCRIPTION
# Changes 
- Arduino Uno R4 WiFi can now send data via HTTP(S).
- DEPLOII_SSL macro will now be set by default to false if the board + protocol does not support a secure connection.
- Receiving data before calling the receive method no longer causes craashes due to missing callbacks.