### PR TITLE
fix: Passwordless wifi on Uno R4

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=deploii
-version=0.3.1
+version=0.3.2
 author=Company of Things
 maintainer=Company of Things <post@cot.as>
 sentence=Library for enabling communication between a MCU and Deploii

--- a/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
+++ b/src/handler/arduino_uno_r4_wifi/deploii_handler_arduino_uno_r4_wifi.h
@@ -156,7 +156,8 @@ public:
   {
     DEPLOII_DPRINT(DEPLOII_DEBUG_INFO, "[WiFi] Attempting to connect to WiFi...");
 
-    WiFi.begin(ssid, pwd);
+    if (pwd[0]=='\0') WiFi.begin(ssid, nullptr); // Pass nullptr for networks without password
+    else  WiFi.begin(ssid, pwd);
 
     while (WiFi.status() != WL_CONNECTED)
     {


### PR DESCRIPTION
# Changes
- Can now connect to WiFi on Uno R4 without password by passing empty string
- Updated semver for new release